### PR TITLE
Escape EOF

### DIFF
--- a/BuildPiKernel64bit.sh
+++ b/BuildPiKernel64bit.sh
@@ -759,7 +759,7 @@ EOF
 
 # % Startup tweaks to fix bluetooth and sound issues
 sudo touch /mnt/etc/rc.local
-cat << EOF | sudo tee /mnt/etc/rc.local
+cat << \EOF | sudo tee /mnt/etc/rc.local
 #!/bin/bash
 #
 # rc.local


### PR DESCRIPTION
You have to escape the EOF. Otherwise the commands and variables will be interpreted:

```shell
#!/bin/bash
#
# rc.local
#
# Fix sound
if [ -n "/usr/bin/pulseaudio" ]; then
  GrepCheck=
  if [ -z "" ]; then
    sed -i "s:load-module module-udev-detect:load-module module-udev-detect tsched=0:g" /etc/pulse/default.pa
  else
    GrepCheck=
    if [ ! -z "" ]; then
        sed -i 's/tsched=0//g' /etc/pulse/default.pa
        sed -i "s:load-module module-udev-detect:load-module module-udev-detect tsched=0:g" /etc/pulse/default.pa
    fi
  fi
fi
# Enable bluetooth
if [ -n "/usr/bin/hciattach" ]; then
  echo "Attaching Bluetooth controller ..."
  hciattach /dev/ttyAMA0 bcm43xx 921600
fi
exit 0
```

By the way, thank you very much for your work!